### PR TITLE
score updates on snapshot change in firestore

### DIFF
--- a/public/scripts/main.js
+++ b/public/scripts/main.js
@@ -50,12 +50,17 @@ window.onload = () => {
         totalClicks = dbData["clicks"] || 0
         document.getElementById("totalclicks").innerText = totalClicks
         generateLeaderboard()
-    })
 
+        firebase.firestore().collection("game").doc(userDetails["email"]).onSnapshot((doc) => {
+            let tempData = doc.data()
+            document.getElementById("totalclicks").innerText = tempData["clicks"]
+        })
+    })
 
     document.getElementsByClassName("btn-holder")[0].onclick = () => {
         increaseCount()
     }
+
 }
 
 const createPlusOneAnimation = () => {
@@ -92,7 +97,6 @@ const increaseCount = () => {
     }
 
     totalClicks++
-    document.getElementById("totalclicks").innerText = totalClicks
 }
 
 const googleSignIn = () => {


### PR DESCRIPTION
## Issue:
Previously total click had a glitch, if users starts clicking the button before `total clicks` data is retrieved from the firestore, the total clicks will reflect only the current count of click not the actual total clicks.

## Fix:
using `.onSnapshot` feature with firestore when ever there's some change in the current user document, a function will fire up that will re-correct the total click value to its correct one.